### PR TITLE
Add a script to generate key presses from the gamepad

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -155,6 +155,10 @@ bindsym XF86MonBrightnessDown exec brightnessctl set 1-
 bindsym XF86MonBrightnessUp   exec brightnessctl set +1
 bindsym Print                 exec $screenshot
 
+# Convert gamepad inputs to keyboard keys. Comment the following line
+# if you don't want this behavior.
+exec ~/bin/gamepad.py
+
 # start terminal at launch
 exec $term
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ compatible with `i3`.
 
 ### Custom Scripts
 
-| File          | Function                                  |
-|---------------|-------------------------------------------|
-| `bin/font.sh` | choose a linux console font interactively |
-| `battery.sh`  | outputs current battery status            |
+| File          | Function                                   |
+|---------------|--------------------------------------------|
+| `bin/font.sh` | choose a linux console font interactively  |
+| `battery.sh`  | outputs current battery status             |
+| `gamepad.py`  | translates gamepad inputs into key presses |
 
 ### Sway Config
 
@@ -33,6 +34,7 @@ compatible with `i3`.
     multiple on the current workspace.
 - Configures `swaybar` with workspace switcher, clock, and battery status.
 - Brightness control keys work
+- Starts helper script to convert gamepad input to key presses.
   
 #### Key Bindings
 
@@ -42,6 +44,10 @@ the `Super` key, and *then* type the corresponding action key.
 For example, to open a terminal, type `Super_R` (`Fn` + `Alt_L`)
 *followed by* `Enter`. If you are already used to the default key
 bindings, this should be an easy adjustment.
+
+Gamepad inputs are converted to keyboard inputs via `gamepad.py` in
+the bin directory. You can change the key bindings by editing KEYMAP
+table in this script.
 
 #### Cheat Sheet
 

--- a/bin/gamepad.py
+++ b/bin/gamepad.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+#
+# Watch input events on the gamepad, and re-inject as keyboard events
+# according to this config.
+#
+# Depends: input-utils, wtype, and python3-pexpect packages.
+#
+# A word of caution: this script has to do a fair amount of processing
+# per event, so you probably want to disable this script for actual
+# gaming.
+
+# TBD: implement an easy way to inhibit this script for actual
+#      gameplay.
+# TBD: allow binding arbitrary shell commands / sway commands.
+
+import os
+import pexpect
+import re
+
+# Symbolic names for the keycodes. Don't touch these.
+SELECT = b"128"
+START  = b"129"
+Y      = b"123"
+X      = b"120"
+B      = b"122"
+A      = b"121"
+
+# Edit this table to suit your preferences.
+KEYMAP = {
+    SELECT: "Super_L",
+    START:  "Super_R",
+    Y:      "Insert",
+    X:      "Prior",
+    B:      "Delete",
+    A:      "Next",
+}
+
+# Corresponds to /dev/input/event5, which seems to be the gamepad. Not
+# sure if it can change. I guess we'll see.
+DEV_NUMBER = 5
+
+# Regular expressions given to `expect()`.
+EVENT_RES  = [
+    # Matches the actual information we want, so it's given first.
+    r"\(0x(\d+)\) (pressed|released)\r\n",
+    # Matches anything else to avoid a match error.
+    r"\.*\r\n",
+]
+
+# Send the key code via wtype.
+def send_key(code, state):
+    keysym = KEYMAP[code]
+    if state == b"pressed":
+        print(f"{code} -> {keysym} pressed")
+        os.system(f"wtype -P {keysym}")
+    else:
+        print(f"{code} -> {keysym} released")
+        os.system(f"wtype -p {keysym}")
+
+# Run forever
+while True:
+    # Spawn `input-events` subprocess and wait for it to signal that
+    # it is ready.
+    print("spawning")
+    child = pexpect.spawn(f"input-events -t 3000 {DEV_NUMBER}")
+    child.expect("waiting for events")
+    try:
+        # decode each event as it comes in.
+        while True:
+            if child.expect(EVENT_RES, timeout=None) == 0:
+                (code, state) = child.match.groups(1)
+                send_key(code, state)
+    except KeyboardInterrupt:
+        exit(1)
+    except pexpect.exceptions.EOF:
+        # The process might time out or otherwise fail. -- there is no
+        # way to tell `input-events` that you want an infinite
+        # timeout.
+        print(f"subprocess terminated {e}")

--- a/src/install-deps.sh
+++ b/src/install-deps.sh
@@ -21,6 +21,9 @@ PKGS+=(ttf-ancient-fonts)
 PKGS+=(grim)
 PKGS+=(bat)
 PKGS+=(delta)
+PKGS+=(wtype)
+PKGS+=(input-utils)
+PKGS+=(python3-pexpect)
 
 # Recommended packages -- adjust to your preferences.
 PKGS+=(emacs-nox)


### PR DESCRIPTION
This works, sortof, but has some consequences I don't like. I will leave this branch up here in case anyone is desperate for this functionality, and willing to put up with the following issues:

- modifier keys don't work with the gamepad keys
- focus isn't set properly, like it is with the actual keyboard
- the script causes init to hang when shutting down, until the task times out.

So this code will live on this branch until I sort out these issues.